### PR TITLE
add "" to judge whether the environment variable exists"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 workdir=$(dirname $(realpath $0))
 version=$(cat version 2>/dev/null)
 folder_name="polaris-server-release_${version}"
-if [ -n $GOOS ] && [ -n $GOARCH ]
+if [ -n "$GOOS" ] && [ -n "$GOARCH" ]
 then
 	folder_name="polaris-server-release_${version}.${GOOS}.${GOARCH}"
 fi

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,9 @@ set -e
 
 workdir=$(dirname $(realpath $0))
 version=$(cat version 2>/dev/null)
-folder_name="polaris-server-release_${version}"
-if [ -n "$GOOS" ] && [ -n "$GOARCH" ]
-then
-	folder_name="polaris-server-release_${version}.${GOOS}.${GOARCH}"
-fi
+GOOS=`go env GOOS`
+GOARCH=`go env GOARCH`
+folder_name="polaris-server-release_${version}.${GOOS}.${GOARCH}"
 pkg_name="${folder_name}.tar.gz"
 
 cd $workdir


### PR DESCRIPTION
when the `GOOS` and `GOARCH` environment variable do not exist

the `build.sh` script echo `polaris-server-release_v1.0.1..`

`if [ -n $GOOS ] && [ -n $GOARCH ]` should be replace by `if [ -n "$GOOS" ] && [ -n "$GOARCH" ]`