### PR TITLE
password is not required

### DIFF
--- a/store/defaultStore/default.go
+++ b/store/defaultStore/default.go
@@ -156,7 +156,7 @@ func parseStoreConfig(opts interface{}) (*dbConfig, error) {
 	dbPwd, _ := obj["dbPwd"].(string)
 	dbAddr, _ := obj["dbAddr"].(string)
 	dbName, _ := obj["dbName"].(string)
-	if dbType == "" || dbUser == "" || dbPwd == "" || dbAddr == "" || dbName == "" {
+	if dbType == "" || dbUser == "" || dbAddr == "" || dbName == "" {
 		return nil, fmt.Errorf("Config Plugin %s missing database param", STORENAME)
 	}
 


### PR DESCRIPTION
fixes #99

mysql password is not required.
```
 mac@apples-MacBook-Pro ~  mysql -uroot
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 30
Server version: 8.0.26 Homebrew

Copyright (c) 2000, 2021, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql>
```