### PR TITLE
Fix script error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,15 +5,15 @@ set -e
 workdir=$(dirname $(realpath $0))
 version=$(cat version 2>/dev/null)
 bin_name="polaris-server"
-if [ ${GOOS} == "" ];then
+if [ "${GOOS}" == "" ];then
   GOOS=`go env GOOS`
 fi
-if [ ${GOARCH} == "" ];then
+if [ "${GOARCH}" == "" ];then
   GOARCH=`go env GOARCH`
 fi
 folder_name="polaris-server-release_${version}.${GOOS}.${GOARCH}"
 pkg_name="${folder_name}.zip"
-if [ ${GOOS} == "windows" ];then
+if [ "${GOOS}" == "windows" ];then
   bin_name="polaris-server.exe"
 fi
 echo "GOOS is ${GOOS}, binary name is ${bin_name}"


### PR DESCRIPTION
There is an error in build.sh, when run it I got the error message: 

```
./build.sh: line 8: [: ==: unary operator expected
./build.sh: line 11: [: ==: unary operator expected
./build.sh: line 16: [: ==: unary operator expected
GOOS is , binary name is polaris-server
  adding: polaris-server-release_v1.2.1../ (stored 0%)
  adding: polaris-server-release_v1.2.1../tool/ (stored 0%)
  adding: polaris-server-release_v1.2.1../tool/check.sh (deflated 50%)
  adding: polaris-server-release_v1.2.1../tool/start.bat (deflated 53%)
  adding: polaris-server-release_v1.2.1../tool/reload.sh (deflated 52%)
  adding: polaris-server-release_v1.2.1../tool/start.sh (deflated 50%)
  adding: polaris-server-release_v1.2.1../tool/p.sh (deflated 51%)
  adding: polaris-server-release_v1.2.1../tool/stop.bat (deflated 41%)
  adding: polaris-server-release_v1.2.1../tool/stop.sh (deflated 51%)
  adding: polaris-server-release_v1.2.1../tool/p.bat (deflated 40%)
  adding: polaris-server-release_v1.2.1../tool/include (deflated 69%)
  adding: polaris-server-release_v1.2.1../polaris-server (deflated 50%)
  adding: polaris-server-release_v1.2.1../polaris-server.yaml (deflated 65%)
```

We can see, GOOS is not right. 
This PR will fix this issue.