### PR TITLE
perf:use sync.RWMutex replace sync.Mutex in counter

### DIFF
--- a/common/connlimit/listener.go
+++ b/common/connlimit/listener.go
@@ -40,7 +40,7 @@ const (
 type counter struct {
 	size       int32
 	actives    map[string]*Conn // 活跃的连接
-	mu         sync.RWMutex
+	mu         *sync.RWMutex
 	lastAccess int64
 }
 
@@ -49,7 +49,7 @@ func newCounter() *counter {
 	return &counter{
 		size:       1,
 		actives:    make(map[string]*Conn),
-		mu:         sync.RWMutex{},
+		mu:         &sync.RWMutex{},
 		lastAccess: time.Now().Unix(),
 	}
 }


### PR DESCRIPTION
**Please provide issue(s) of this PR:
Optimize the use of locks，distinguish between read lock and write lock.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [ ] Installation
- [x] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
