### PR TITLE
[ISSUE#157]fix:clean namespace's servicecache when delete namespace

### DIFF
--- a/naming/cache/instance.go
+++ b/naming/cache/instance.go
@@ -70,7 +70,7 @@ type instanceCache struct {
 	lastMtimeLogged  int64
 	firstUpdate      bool
 	ids              *sync.Map // instanceid -> instance
-	services         *sync.Map // service id -> [instanceid ->instace]
+	services         *sync.Map // service id -> [instanceid ->instance]
 	instanceCounts   *sync.Map // service id -> [instanceCount]
 	revisionCh       chan *revisionNotify
 	disableBusiness  bool

--- a/naming/cache/instance.go
+++ b/naming/cache/instance.go
@@ -69,8 +69,8 @@ type instanceCache struct {
 	lastMtime        int64
 	lastMtimeLogged  int64
 	firstUpdate      bool
-	ids              *sync.Map // id -> instance
-	services         *sync.Map // service id -> [instances]
+	ids              *sync.Map // instanceid -> instance
+	services         *sync.Map // service id -> [instanceid ->instace]
 	instanceCounts   *sync.Map // service id -> [instanceCount]
 	revisionCh       chan *revisionNotify
 	disableBusiness  bool

--- a/naming/cache/service.go
+++ b/naming/cache/service.go
@@ -79,8 +79,8 @@ type serviceCache struct {
 	lastMtime       int64
 	lastMtimeLogged int64
 	firstUpdate     bool
-	ids             *sync.Map // id -> service
-	names           *sync.Map // space -> [serviceName -> service]
+	ids             *sync.Map // serviceid -> service
+	names           *sync.Map // spacename -> [serviceName -> service]
 	cl5Sid2Name     *sync.Map // 兼容Cl5，sid -> name
 	cl5Names        *sync.Map // 兼容Cl5，name -> service
 	revisionCh      chan *revisionNotify

--- a/naming/cache/service.go
+++ b/naming/cache/service.go
@@ -54,6 +54,9 @@ type ServiceCache interface {
 	// IteratorServices 迭代缓存的服务信息
 	IteratorServices(iterProc ServiceIterProc) error
 
+	// GetServicesNames 获取所有服务缓存
+	GetServicesCache() *sync.Map
+
 	// GetServicesCount 获取缓存中服务的个数
 	GetServicesCount() int
 
@@ -216,6 +219,14 @@ func (sc *serviceCache) GetServiceByName(name string, namespace string) *model.S
 	}
 
 	return value.(*model.Service)
+}
+
+/**
+ * GetServicesCache 获取所有服务的缓存
+ */
+func (sc *serviceCache) GetServicesCache() *sync.Map {
+
+	return sc.names
 }
 
 /**

--- a/naming/cache/service.go
+++ b/naming/cache/service.go
@@ -54,8 +54,8 @@ type ServiceCache interface {
 	// IteratorServices 迭代缓存的服务信息
 	IteratorServices(iterProc ServiceIterProc) error
 
-	// GetServicesNames 获取所有服务缓存
-	GetServicesCache() *sync.Map
+	// CleanNamespace 清除Namespace对应服务的缓存
+	CleanNamespace(namespace string)
 
 	// GetServicesCount 获取缓存中服务的个数
 	GetServicesCount() int
@@ -222,11 +222,11 @@ func (sc *serviceCache) GetServiceByName(name string, namespace string) *model.S
 }
 
 /**
- * GetServicesCache 获取所有服务的缓存
+ * CleanNamespace 清除Namespace对应的服务缓存
  */
-func (sc *serviceCache) GetServicesCache() *sync.Map {
+func (sc *serviceCache) CleanNamespace(namespace string) {
 
-	return sc.names
+	 sc.names.Delete(namespace)
 }
 
 /**

--- a/naming/namespace.go
+++ b/naming/namespace.go
@@ -186,7 +186,7 @@ func (s *Server) DeleteNamespace(ctx context.Context, req *api.Namespace) *api.R
 		return api.NewNamespaceResponse(api.StoreLayerException, req)
 	}
 
-	s.deleteServiceCache(namespace.Name)
+	s.caches.Service().CleanNamespace(namespace.Name)
 
 	msg := fmt.Sprintf("delete namepsace: name=%v", namespace.Name)
 	log.Info(msg, zap.String("request-id", requestID))
@@ -383,13 +383,6 @@ func (s *Server) checkNamespaceAuthority(ctx context.Context, req *api.Namespace
 	}
 
 	return namespace, nil
-}
-
-// 删除namespace对应的serviceche
-func (s *Server) deleteServiceCache(namespace string) {
-
-	 s.caches.Service().CleanNamespace(namespace)
-
 }
 
 /*

--- a/naming/namespace.go
+++ b/naming/namespace.go
@@ -20,6 +20,7 @@ package naming
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	api "github.com/polarismesh/polaris-server/common/api/v1"
@@ -185,7 +186,7 @@ func (s *Server) DeleteNamespace(ctx context.Context, req *api.Namespace) *api.R
 		log.Error(err.Error(), zap.String("request-id", requestID))
 		return api.NewNamespaceResponse(api.StoreLayerException, req)
 	}
-
+	s.caches.Service().GetServicesCache().Store(namespace.Name, new(sync.Map))
 	msg := fmt.Sprintf("delete namepsace: name=%v", namespace.Name)
 	log.Info(msg, zap.String("request-id", requestID))
 	s.RecordHistory(namespaceRecordEntry(ctx, req, model.ODelete))

--- a/naming/namespace.go
+++ b/naming/namespace.go
@@ -20,7 +20,6 @@ package naming
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	api "github.com/polarismesh/polaris-server/common/api/v1"
@@ -186,7 +185,9 @@ func (s *Server) DeleteNamespace(ctx context.Context, req *api.Namespace) *api.R
 		log.Error(err.Error(), zap.String("request-id", requestID))
 		return api.NewNamespaceResponse(api.StoreLayerException, req)
 	}
-	s.caches.Service().GetServicesCache().Store(namespace.Name, new(sync.Map))
+
+	s.deleteservicecache(namespace.Name)
+
 	msg := fmt.Sprintf("delete namepsace: name=%v", namespace.Name)
 	log.Info(msg, zap.String("request-id", requestID))
 	s.RecordHistory(namespaceRecordEntry(ctx, req, model.ODelete))
@@ -382,6 +383,12 @@ func (s *Server) checkNamespaceAuthority(ctx context.Context, req *api.Namespace
 	}
 
 	return namespace, nil
+}
+
+// 删除namespace对应的serviceche
+func (s *Server) deleteservicecache(namespace string) {
+	ServicesCache:=s.caches.Service().GetServicesCache()
+	ServicesCache.Delete(namespace)
 }
 
 /*

--- a/naming/namespace.go
+++ b/naming/namespace.go
@@ -186,7 +186,7 @@ func (s *Server) DeleteNamespace(ctx context.Context, req *api.Namespace) *api.R
 		return api.NewNamespaceResponse(api.StoreLayerException, req)
 	}
 
-	s.deleteservicecache(namespace.Name)
+	s.deleteServiceCache(namespace.Name)
 
 	msg := fmt.Sprintf("delete namepsace: name=%v", namespace.Name)
 	log.Info(msg, zap.String("request-id", requestID))
@@ -386,7 +386,7 @@ func (s *Server) checkNamespaceAuthority(ctx context.Context, req *api.Namespace
 }
 
 // 删除namespace对应的serviceche
-func (s *Server) deleteservicecache(namespace string) {
+func (s *Server) deleteServiceCache(namespace string) {
 	ServicesCache:=s.caches.Service().GetServicesCache()
 	ServicesCache.Delete(namespace)
 }

--- a/naming/namespace.go
+++ b/naming/namespace.go
@@ -387,8 +387,9 @@ func (s *Server) checkNamespaceAuthority(ctx context.Context, req *api.Namespace
 
 // 删除namespace对应的serviceche
 func (s *Server) deleteServiceCache(namespace string) {
-	ServicesCache:=s.caches.Service().GetServicesCache()
-	ServicesCache.Delete(namespace)
+
+	 s.caches.Service().CleanNamespace(namespace)
+
 }
 
 /*


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #https://github.com/polarismesh/polaris/issues/157
namespace 能被删除的其中一个前提是对应的service 已经全部被删除了，但service被删除的时候service对应的内存地址空间没有清除，所以在删除namespace 的时候顺带清除对应的内存。

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [x] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
