### PR TITLE
fix: console_access.go interface response structure, use handler.WriteHeaderAndProto replace handler.WriteHeader

### DIFF
--- a/apiserver/httpserver/console_access.go
+++ b/apiserver/httpserver/console_access.go
@@ -208,7 +208,7 @@ func (h *HTTPServer) DeleteNamespaces(req *restful.Request, rsp *restful.Respons
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -234,7 +234,7 @@ func (h *HTTPServer) UpdateNamespaces(req *restful.Request, rsp *restful.Respons
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -322,7 +322,7 @@ func (h *HTTPServer) DeleteServices(req *restful.Request, rsp *restful.Response)
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -347,7 +347,7 @@ func (h *HTTPServer) UpdateServices(req *restful.Request, rsp *restful.Response)
 		handler.WriteHeaderAndProto(ret)
 		return
 	}
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -433,7 +433,7 @@ func (h *HTTPServer) UpdateServiceAlias(req *restful.Request, rsp *restful.Respo
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 // DeleteServiceAlias 删除服务别名
@@ -456,7 +456,7 @@ func (h *HTTPServer) DeleteServiceAliases(req *restful.Request, rsp *restful.Res
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 // GetServiceAliases 根据源服务获取服务别名
@@ -511,7 +511,7 @@ func (h *HTTPServer) DeleteInstances(req *restful.Request, rsp *restful.Response
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -537,7 +537,7 @@ func (h *HTTPServer) DeleteInstancesByHost(req *restful.Request, rsp *restful.Re
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -563,7 +563,7 @@ func (h *HTTPServer) UpdateInstances(req *restful.Request, rsp *restful.Response
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -589,7 +589,7 @@ func (h *HTTPServer) UpdateInstancesIsolate(req *restful.Request, rsp *restful.R
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -657,7 +657,7 @@ func (h *HTTPServer) DeleteRoutings(req *restful.Request, rsp *restful.Response)
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -683,7 +683,7 @@ func (h *HTTPServer) UpdateRoutings(req *restful.Request, rsp *restful.Response)
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -739,7 +739,7 @@ func (h *HTTPServer) DeleteRateLimits(req *restful.Request, rsp *restful.Respons
 		handler.WriteHeaderAndProto(ret)
 		return
 	}
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -765,7 +765,7 @@ func (h *HTTPServer) UpdateRateLimits(req *restful.Request, rsp *restful.Respons
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -842,7 +842,7 @@ func (h *HTTPServer) DeleteCircuitBreakers(req *restful.Request, rsp *restful.Re
 		handler.WriteHeaderAndProto(ret)
 		return
 	}
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -867,7 +867,7 @@ func (h *HTTPServer) UpdateCircuitBreakers(req *restful.Request, rsp *restful.Re
 		handler.WriteHeaderAndProto(ret)
 		return
 	}
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -892,7 +892,7 @@ func (h *HTTPServer) ReleaseCircuitBreakers(req *restful.Request, rsp *restful.R
 		handler.WriteHeaderAndProto(ret)
 		return
 	}
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -917,7 +917,7 @@ func (h *HTTPServer) UnBindCircuitBreakers(req *restful.Request, rsp *restful.Re
 		handler.WriteHeaderAndProto(ret)
 		return
 	}
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -1056,7 +1056,7 @@ func (h *HTTPServer) UpdatePlatforms(req *restful.Request, rsp *restful.Response
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**
@@ -1081,7 +1081,7 @@ func (h *HTTPServer) DeletePlatforms(req *restful.Request, rsp *restful.Response
 		return
 	}
 
-	handler.WriteHeader(ret.GetCode().GetValue(), http.StatusOK)
+	handler.WriteHeaderAndProto(ret)
 }
 
 /**


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes # #219

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**



- [ ] Configuration
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
