### PR TITLE
style:use  instead of time.Since instead of time.Now().Sub

### DIFF
--- a/cache/instance.go
+++ b/cache/instance.go
@@ -169,11 +169,11 @@ func (ic *instanceCache) realUpdate() error {
 
 	ic.firstUpdate = false
 	update, del := ic.setInstances(instances)
-	timeDiff := time.Now().Sub(start)
+	timeDiff := time.Since(start)
 	if timeDiff > 1*time.Second {
 		log.CacheScope().Info("[Cache][Instance] get more instances",
 			zap.Int("update", update), zap.Int("delete", del),
-			zap.Time("last", lastMtime), zap.Duration("used", time.Now().Sub(start)))
+			zap.Time("last", lastMtime), zap.Duration("used", time.Since(start)))
 	}
 	return nil
 }

--- a/plugin/auth/platform/platform.go
+++ b/plugin/auth/platform/platform.go
@@ -143,7 +143,7 @@ func (a *Auth) update() error {
 
 	update, del := a.setPlatform(out)
 	log.Info("[Plugin][platform] get more platforms", zap.Int("update", update), zap.Int("delete", del),
-		zap.Time("last", a.lastMtime), zap.Duration("used", time.Now().Sub(start)))
+		zap.Time("last", a.lastMtime), zap.Duration("used", time.Since(start)))
 	return nil
 }
 


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #https://github.com/polarismesh/polaris/issues/223

 use `time.Since` instead of `time.Now().Sub`

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
