### PR TITLE
style:use range instead of select

### DIFF
--- a/common/connlimit/listener_test.go
+++ b/common/connlimit/listener_test.go
@@ -99,22 +99,19 @@ func TestConnLimit(t *testing.T) {
 	// time.Sleep(5 * time.Second)
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if atomic.LoadInt32(&total) != int32(connCount) {
-				t.Logf("connection is not finished")
-				continue
-			}
-			hostCnt := lis.(*Listener).GetHostConnCount(host)
-			lisCnt := lis.(*Listener).GetListenerConnCount()
-			if hostCnt == 0 && lisCnt == 0 {
-				t.Logf("pass")
-				return
-			}
-
-			t.Logf("host conn count:%d: lis conn count:%d", hostCnt, lisCnt)
+	for range ticker.C {
+		if atomic.LoadInt32(&total) != int32(connCount) {
+			t.Logf("connection is not finished")
+			continue
 		}
+		hostCnt := lis.(*Listener).GetHostConnCount(host)
+		lisCnt := lis.(*Listener).GetListenerConnCount()
+		if hostCnt == 0 && lisCnt == 0 {
+			t.Logf("pass")
+			return
+		}
+
+		t.Logf("host conn count:%d: lis conn count:%d", hostCnt, lisCnt)
 	}
 }
 

--- a/common/redispool/redis_pool.go
+++ b/common/redispool/redis_pool.go
@@ -353,9 +353,7 @@ func sleep(dur time.Duration) {
 	t := time.NewTimer(dur)
 	defer t.Stop()
 
-	select {
-	case <-t.C:
-	}
+	<-t.C
 }
 
 // checkRedis check redis alive

--- a/plugin/auth/platform/platform.go
+++ b/plugin/auth/platform/platform.go
@@ -125,11 +125,8 @@ func (a *Auth) run() {
 	ticker := time.NewTicker(a.interval)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-ticker.C:
-			_ = a.update()
-		}
+	for range ticker.C {
+		_ = a.update()
 	}
 }
 

--- a/service/healthcheck/check.go
+++ b/service/healthcheck/check.go
@@ -92,13 +92,11 @@ func newCheckScheduler(ctx context.Context, slotNum int,
 func (c *CheckScheduler) doCheck(ctx context.Context) {
 	c.timeWheel.Start()
 	log.Infof("[Health Check][Check]timeWheel has been started")
-	for {
-		select {
-		case <-ctx.Done():
-			c.timeWheel.Stop()
-			log.Infof("[Health Check][Check]timeWheel has been stopped")
-			return
-		}
+
+	for range ctx.Done() {
+		c.timeWheel.Stop()
+		log.Infof("[Health Check][Check]timeWheel has been stopped")
+		return
 	}
 }
 

--- a/service/healthcheck/check.go
+++ b/service/healthcheck/check.go
@@ -93,11 +93,9 @@ func (c *CheckScheduler) doCheck(ctx context.Context) {
 	c.timeWheel.Start()
 	log.Infof("[Health Check][Check]timeWheel has been started")
 
-	for range ctx.Done() {
-		c.timeWheel.Stop()
-		log.Infof("[Health Check][Check]timeWheel has been stopped")
-		return
-	}
+	<-ctx.Done()
+	c.timeWheel.Stop()
+	log.Infof("[Health Check][Check]timeWheel has been stopped")
 }
 
 const (

--- a/service/healthcheck/server.go
+++ b/service/healthcheck/server.go
@@ -181,26 +181,22 @@ func (s *Server) receiveEventAndPush() {
 		return
 	}
 
-	for {
-		select {
-		case wrapper := <-s.discoverCh:
-			svcId := wrapper.ServiceID
-			event := wrapper.Event
-			var service *model.Service
-			for {
-				service = s.serviceCache.GetServiceByID(svcId)
-				if service == nil {
-					time.Sleep(time.Duration(500 * time.Millisecond))
-					continue
-				}
-				break
+	for wrapper := range s.discoverCh {
+		svcId := wrapper.ServiceID
+		event := wrapper.Event
+		var service *model.Service
+		for {
+			service = s.serviceCache.GetServiceByID(svcId)
+			if service == nil {
+				time.Sleep(500 * time.Millisecond)
+				continue
 			}
-
-			event.Namespace = service.Namespace
-			event.Service = service.Name
-
-			s.discoverEvent.PublishEvent(event)
+			break
 		}
+		event.Namespace = service.Namespace
+		event.Service = service.Name
+
+		s.discoverEvent.PublishEvent(event)
 	}
 
 }

--- a/service/test/instance_test.go
+++ b/service/test/instance_test.go
@@ -1147,12 +1147,9 @@ func TestBatchCreateInstances(t *testing.T) {
 		var deleteCount int32
 		for i := 0; i < n; i++ {
 			go func() {
-				for {
-					select {
-					case id := <-idCh:
-						cleanInstance(id)
-						atomic.AddInt32(&deleteCount, 1)
-					}
+				for id := range idCh {
+					cleanInstance(id)
+					atomic.AddInt32(&deleteCount, 1)
 				}
 			}()
 		}


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes https://github.com/polarismesh/polaris/issues/223

use for range instead of for { select {} };
 
use a simple channel send/receive instand of  `select ` with a single case

select 监听单一channel时，在go实现层面编译器会将 select 改写成 if 条件语句
可参考下面这边blog 的介绍
https://draveness.me/golang/docs/part2-foundation/ch05-keyword/golang-select/ 
根据golangci-lint 的检测提示，可以将检测出的case 修改成 从channel中阻塞读取，功能上等价


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
