### PR TITLE
feat: add redis options of minIdleConns and poolSize

### DIFF
--- a/deploy/helm/templates/polaris-server-config.yaml
+++ b/deploy/helm/templates/polaris-server-config.yaml
@@ -246,7 +246,8 @@ data:
             {{- if .Values.polaris.storage.redis.password }}
             kvPasswd: {{ .Values.polaris.storage.redis.password }}
             {{- end }}
-            maxIdle: 200
+            poolSize: 200
+            minIdleConns: 30
             idleTimeout: 120s
             connectTimeout: 200ms
             msgTimeout: 200ms

--- a/deploy/standalone/k8s/02-polaris-server-config.yaml
+++ b/deploy/standalone/k8s/02-polaris-server-config.yaml
@@ -239,7 +239,8 @@ data:
     #      kvAddr: ##REDIS_ADDR##
     #      kvUser: ##REDIS_USER#
     #      kvPasswd: ##REDIS_PWD##
-    #      maxIdle: 200
+    #      poolSize: 200
+    #      minIdleConns: 30
     #      idleTimeout: 120s
     #      connectTimeout: 200ms
     #      msgTimeout: 200ms

--- a/polaris-server.yaml
+++ b/polaris-server.yaml
@@ -238,7 +238,8 @@ healthcheck:
 #      kvAddr: ##REDIS_ADDR##
 #      kvUser: ##REDIS_USER#
 #      kvPasswd: ##REDIS_PWD##
-#      maxIdle: 200
+#      poolSize: 200
+#      minIdleConns: 30
 #      idleTimeout: 120s
 #      connectTimeout: 200ms
 #      msgTimeout: 200ms

--- a/test/discover/test.yaml
+++ b/test/discover/test.yaml
@@ -127,7 +127,8 @@ healthcheck:
 #      kvAddr: ##REDIS_ADDR##
 #      kvUser: ##REDIS_USER#
 #      kvPasswd: ##REDIS_PWD##
-#      maxIdle: 200
+#      poolSize: 200
+#      minIdleConns: 30
 #      idleTimeout: 120s
 #      connectTimeout: 200ms
 #      msgTimeout: 200ms


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #404 

- removed `maxIdle` option of redis
- added `poolSize` and `minIdleConns` options of redis
- updated yaml and helm templates, default `poolSize` is 200 and default `minIdleConns` is 30

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Configuration
- [ ] Docs
- [X] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [X] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
