### PR TITLE
feat: add docker-compose based development environment

### DIFF
--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -21,9 +21,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/polarismesh/polaris-server/common/utils"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/polarismesh/polaris-server/common/utils"
 )
 
 var (
@@ -39,7 +41,11 @@ func GetRegistry() *prometheus.Registry {
 
 // GetHttpHandler 获取 handler
 func GetHttpHandler() http.Handler {
-	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	// 添加 Golang runtime metrics
+	registry.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollections(collectors.GoRuntimeMetricsCollection),
+	))
+	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{EnableOpenMetrics: true})
 }
 
 func InitMetrics() {

--- a/development/console/polaris-console.yaml
+++ b/development/console/polaris-console.yaml
@@ -1,0 +1,25 @@
+logger:
+  RotateOutputPath: log/polaris-console.log
+  RotationMaxSize: 500
+  RotationMaxAge: 30
+  RotationMaxBackups: 100
+  level: info
+webServer:
+  mode: "release"
+  listenIP: "0.0.0.0"
+  listenPort: 8080
+  namingURL: "/naming/v1"
+  authURL: "/core/v1"
+  requestURL: "/naming/v1"
+  configURL: "/config/v1"
+  monitorURL: "/api/v1"
+  webPath: "web/dist/"
+polarisServer:
+  address: "polaris-server:8090"
+  polarisToken: "polaris@12345678"
+monitorServer:
+  address: "prometheus:9090"
+oaAuthority:
+  enableOAAuth: false
+hrData:
+  enableHrData: false

--- a/development/console/polaris-console.yaml
+++ b/development/console/polaris-console.yaml
@@ -18,7 +18,7 @@ polarisServer:
   address: "polaris-server:8090"
   polarisToken: "polaris@12345678"
 monitorServer:
-  address: "prometheus:9090"
+  address: "polaris-prometheus:9090"
 oaAuthority:
   enableOAAuth: false
 hrData:

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
       - ./mysql/mysqld.cnf:/etc/mysql/conf.d/custom.cnf:cached
       - ../store/sqldb/scripts/polaris_server.sql:/docker-entrypoint-initdb.d/polaris_server.sql
     ports:
-      - "0.0.0.0:3306:3306"
+      - "3306:3306"
     networks:
       - backend
   redis:
@@ -74,7 +74,7 @@ services:
     networks:
       - backend
     ports:
-      - '0.0.0.0:6379:6379'
+      - '6379:6379'
   redis-slave:
     image: 'bitnami/redis:latest'
     environment:
@@ -111,7 +111,7 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
-      - "0.0.0.0:9090:9090"
+      - "9090:9090"
     networks:
       - backend
   polaris-pushgateway:
@@ -119,13 +119,20 @@ services:
     image: prom/pushgateway
     hostname: polaris-pushgateway
     ports:
-      - "0.0.0.0:9091:9091"
+      - "9091:9091"
     networks:
       - backend
   grafana:
     container_name: grafana
-    image: grafana/grafana
+    build: grafana
     ports:
-      - "0.0.0.0:3000:3000"
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning/:/etc/grafana/provisioning/:rw
+      - ./grafana/dashboards:/etc/grafana/dashboards/:rw
+      - ./grafana/grafana.ini:/etc/grafana/grafana.ini:rw
     depends_on:
-      - prometheus
+      - polaris-prometheus
+      - polaris-pushgateway
+    networks:
+      - backend

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -1,0 +1,131 @@
+version: '3'
+
+networks:
+  backend:
+    driver: bridge
+
+volumes:
+  vlm_data_mysql:
+    external: true
+  vlm_redis_sentinel:
+    external: true
+
+services:
+  polaris-server:
+    container_name: polaris-server
+    hostname: polaris-server
+    image: cosmtrek/air
+    volumes:
+      - ../:/data/www/polaris
+      - ~/.ssh:/root/.ssh:cached
+    environment:
+      - GOPROXY=https://proxy.golang.com.cn,direct
+    working_dir: /data/www/polaris
+    entrypoint: [ "air", "-c", "development/server/air.toml", "-d" ]
+    ports:
+      - "8090:8090"    # api-http
+      - "8091:8091"    # service-grpc
+      - "8093:8093"    # config-grpc
+      - "9000:9000"    # prometheus-sd
+      - "8761:8761"    # service-eureka
+      - "15010:15010"  # xds-v3
+    networks:
+      - backend
+    depends_on:
+      - redis-sentinel
+  polaris-console:
+    container_name: polaris-console
+    hostname: polaris-console
+    image: polarismesh/polaris-console
+    volumes:
+      - ./console/polaris-console.yaml:/root/polaris-console.yaml
+    ports:
+      - "8081:8080"
+    networks:
+      - backend
+    depends_on:
+      - polaris-server
+  mysql:
+    container_name: mysql
+    hostname: mysql
+    platform: linux/amd64
+    build: mysql
+    command: mysqld --optimizer-trace-max-mem-size=102400
+    environment:
+      - TZ=Asia/Shanghai
+      - LANG=zh_CN.utf8
+      - MYSQL_DATABASE=default
+      - MYSQL_USER=default
+      - MYSQL_PASSWORD=secret
+      - MYSQL_ROOT_PASSWORD=polaris
+    volumes:
+      - vlm_data_mysql:/var/lib/mysql
+      - ./mysql/mysqld.cnf:/etc/mysql/conf.d/custom.cnf:cached
+      - ../store/sqldb/scripts/polaris_server.sql:/docker-entrypoint-initdb.d/polaris_server.sql
+    ports:
+      - "0.0.0.0:3306:3306"
+    networks:
+      - backend
+  redis:
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=master
+      - REDIS_PASSWORD=polaris
+    networks:
+      - backend
+    ports:
+      - '0.0.0.0:6379:6379'
+  redis-slave:
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis
+      - REDIS_MASTER_PASSWORD=polaris
+      - REDIS_PASSWORD=polaris
+    ports:
+      - '6379'
+    depends_on:
+      - redis
+    networks:
+      - backend
+  redis-sentinel:
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_MASTER_HOST=redis
+      - REDIS_MASTER_USER=polaris
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_MASTER_PASSWORD=polaris
+      - REDIS_SENTINEL_PORT_NUMBER=26379
+      - REDIS_SENTINEL_RESOLVE_HOSTNAMES=yes
+    depends_on:
+      - redis
+      - redis-slave
+    ports:
+      - '26379-26381:26379'
+    networks:
+      - backend
+  polaris-prometheus:
+    container_name: polaris-prometheus
+    image: prom/prometheus
+    hostname: polaris-prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "0.0.0.0:9090:9090"
+    networks:
+      - backend
+  polaris-pushgateway:
+    container_name: polaris-pushgateway
+    image: prom/pushgateway
+    hostname: polaris-pushgateway
+    ports:
+      - "0.0.0.0:9091:9091"
+    networks:
+      - backend
+  grafana:
+    container_name: grafana
+    image: grafana/grafana
+    ports:
+      - "0.0.0.0:3000:3000"
+    depends_on:
+      - prometheus

--- a/development/grafana/Dockerfile
+++ b/development/grafana/Dockerfile
@@ -1,0 +1,9 @@
+FROM grafana/grafana
+
+
+# Disable Login form or not
+ENV GF_AUTH_DISABLE_LOGIN_FORM "true"
+# Allow anonymous authentication or not
+ENV GF_AUTH_ANONYMOUS_ENABLED "true"
+# Role of anonymous user
+ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"

--- a/development/grafana/dashboards/polaris-server.json
+++ b/development/grafana/dashboards/polaris-server.json
@@ -1,0 +1,1044 @@
+{
+  "__inputs": [
+    {
+      "name": "Prometheus",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.3.5"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": 10826,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1567755378675,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_memstats_mspan_inuse_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        },
+        {
+          "expr": "go_memstats_mspan_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        },
+        {
+          "expr": "go_memstats_mcache_inuse_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "C"
+        },
+        {
+          "expr": "go_memstats_mcache_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "D"
+        },
+        {
+          "expr": "go_memstats_buck_hash_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "E"
+        },
+        {
+          "expr": "go_memstats_gc_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "F"
+        },
+        {
+          "expr": "go_memstats_other_sys_bytes - go_memstats_other_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "bytes of memory are used for other runtime allocations {pod={{kubernetes_pod_name}}}",
+          "refId": "G"
+        },
+        {
+          "expr": "go_memstats_next_gc_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory in Off-Heap",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        },
+        {
+          "expr": "go_memstats_heap_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        },
+        {
+          "expr": "go_memstats_heap_idle_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "C"
+        },
+        {
+          "expr": "go_memstats_heap_inuse_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "D"
+        },
+        {
+          "expr": "go_memstats_heap_released_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory in Heap",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_memstats_stack_inuse_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        },
+        {
+          "expr": "go_memstats_stack_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory in Stack",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_memstats_sys_bytes",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Used Memory",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 22,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_memstats_mallocs_total - go_memstats_frees_total",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Number of Live Objects",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "shows how many heap objects are allocated. This is a counter value so you can use rate() to objects allocated/s.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(go_memstats_mallocs_total[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rate of Objects Allocated",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "go_memstats_lookups_total – counts how many pointer dereferences happened. This is a counter value so you can use rate() to lookups/s.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(go_memstats_lookups_total[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rate of a Pointer Dereferences",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_goroutines",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Goroutines",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(go_memstats_alloc_bytes_total[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rates of Allocation",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 4,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "go_gc_duration_seconds",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "GC duration quantile",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 19,
+  "style": "dark",
+  "tags": [
+    "go",
+    "golang"
+  ],
+  "templating": {},
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Polaris Server Runtime metrics",
+  "uid": "CgCw8jKZz",
+  "version": 4,
+  "description": "Polaris Golang Server Runtime metrics"
+}

--- a/development/grafana/grafana.ini
+++ b/development/grafana/grafana.ini
@@ -1,0 +1,12 @@
+[paths]
+provisioning = /etc/grafana/provisioning
+
+[server]
+enable_gzip = true
+
+[security]
+# If you want to embed grafana into an iframe for example
+allow_embedding = true
+
+[users]
+default_theme = dark

--- a/development/grafana/provisioning/dashboards/dashboard.yml
+++ b/development/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,25 @@
+# config file version
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name
+  - name: Polaris Golang Runtime
+    # <int> org id. will default to orgId 1 if not specified
+    org_id: 1
+    # <string, required> name of the dashboard folder. Required
+    folder: ''
+    # <string, required> provider type. Required
+    type: 'file'
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <bool> enable dashboard editing
+    editable: true
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 5
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: true
+    options:
+      # <string, required> path to dashboard files on disk. Required
+      path: /etc/grafana/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: true

--- a/development/grafana/provisioning/datasources/datasource.yml
+++ b/development/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,33 @@
+# config file version
+apiVersion: 1
+
+# list of datasources to insert/update
+datasources:
+  # <string, required> name of the datasource. Required
+  - name: Prometheus
+    # <string, required> datasource type. Required
+    type: prometheus
+    # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
+    access: proxy
+    # <int> org id. will default to orgId 1 if not specified
+    orgId: 1
+    # <string> custom UID which can be used to reference this datasource in other parts of the configuration, if not specified will be generated automatically
+    # uid: my_unique_uid
+    # <string> url
+    url: "http://polaris-prometheus:9090"
+    user:
+    # <string> database name
+    database:
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: true
+    # <bool> mark as default datasource. Max one per org
+    isDefault: true
+    # <map> fields that will be converted to json and stored in jsonData
+    jsonData:
+      httpMethod: POST
+    secureJsonData:
+      # <string> database password, if used
+      password: ""
+    version: 1
+    # <bool> allow users to edit datasources from the UI.
+    editable: true

--- a/development/init.sh
+++ b/development/init.sh
@@ -1,0 +1,4 @@
+
+docker volume create --name=vlm_data_mysql
+docker volume create --name=vlm_data_redis
+docker volume create --name=vlm_log

--- a/development/mysql/Dockerfile
+++ b/development/mysql/Dockerfile
@@ -1,0 +1,14 @@
+FROM mysql:5.7
+
+LABEL maintainer="polaris"
+
+# Set Timezone
+ARG TZ=Asia/Shanghai
+ENV TZ ${TZ}
+RUN pwd \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+	&& echo $TZ > /etc/timezone \
+	&& chown -R mysql:root /var/lib/mysql/ \
+	&& true
+
+EXPOSE 3306

--- a/development/mysql/mysqld.cnf
+++ b/development/mysql/mysqld.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+skip-character-set-client-handshake

--- a/development/prometheus/Dockerfile
+++ b/development/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus/

--- a/development/prometheus/Dockerfile
+++ b/development/prometheus/Dockerfile
@@ -1,2 +1,2 @@
-FROM prom/prometheus
+FROM ccr.ccs.tencentyun.com/polaris_mesh/polaris-pushgateway:1.1.0
 ADD prometheus.yml /etc/prometheus/

--- a/development/prometheus/prometheus.yml
+++ b/development/prometheus/prometheus.yml
@@ -1,0 +1,36 @@
+# my global config
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+# - "first_rules.yml"
+# - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: [ "localhost:9090" ]
+
+  - job_name: "push-metrics"
+    static_configs:
+      - targets: [ "localhost:9091" ]
+  - job_name: "polaris-sd"
+    static_configs:
+      - targets: [ "localhost:9000" ]

--- a/development/prometheus/prometheus.yml
+++ b/development/prometheus/prometheus.yml
@@ -4,33 +4,17 @@ global:
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
 
-# Alertmanager configuration
-alerting:
-  alertmanagers:
-    - static_configs:
-        - targets:
-          # - alertmanager:9093
-
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-# - "first_rules.yml"
-# - "second_rules.yml"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: "prometheus"
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
     static_configs:
       - targets: [ "localhost:9090" ]
-
   - job_name: "push-metrics"
     static_configs:
-      - targets: [ "localhost:9091" ]
-  - job_name: "polaris-sd"
+      - targets: [ "polaris-pushgateway:9091" ]
+  - job_name: "polaris-server"
     static_configs:
-      - targets: [ "localhost:9000" ]
+      - targets: [ "polaris-server:9090" ]

--- a/development/server/air.toml
+++ b/development/server/air.toml
@@ -1,0 +1,53 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o polaris-server ."
+# Binary file yields from `cmd`.
+bin = "polaris-server"
+# Watch these filename extensions.
+include_ext = ["go","yaml", "yml"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["log", "discover-statis", "statis"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = ["/data/www/polaris/polaris.bolt", "polaris.bolt"]
+# Exclude specific regular expressions.
+exclude_regex = ["_test.go", "*.bolt", "*.log"]
+# Exclude unchanged files.
+exclude_unchanged = true
+# Follow symlink for directories
+follow_symlink = true
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 10000 # ms
+# Add additional arguments when running binary (bin/full_bin). Will run './tmp/main hello world'.
+args_bin = ["start"]
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #453

- docker-compose-based development environment, contains `redis-sentinel`、`redis-cluster`、`mysql`、`prometheus`、`grafana`、`polaris-console`.
- polaris-server support hot reload when code or config files changed.
- append golang runtime metrics to `metrics exporter` for performance analysis etc.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.


