### PR TITLE
fix(bootstrap): return error from Start function

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -18,6 +18,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/polarismesh/polaris/bootstrap"
@@ -30,8 +32,14 @@ var (
 		Use:   "start",
 		Short: "start running",
 		Long:  "start running",
-		Run: func(c *cobra.Command, args []string) {
-			bootstrap.Start(configFilePath)
+		Run: func(_ *cobra.Command, _ []string) {
+			config, err := bootstrap.Start(configFilePath)
+			if err != nil {
+				fmt.Printf("[ERROR] %v\n", err)
+			}
+
+			fmt.Println(config)
+			fmt.Println("finish starting server")
 		},
 	}
 )


### PR DESCRIPTION
**About this PR**
I would like to start a Polaris server directly from Go, to use when I run my tests. I found that I can use the `bootstrap.Start` function for this. However, this function was printing out errors, instead of returning them. I would like to print the errors from my custom logger (and it is not idiomatic in Go to not return errors directly), I changed the startup function to return an error, and let the CLI print it out instead.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
