### PR TITLE
polaris 集群模式副本数取值错误问题

### DIFF
--- a/deploy/helm/templates/polaris-server.yaml
+++ b/deploy/helm/templates/polaris-server.yaml
@@ -43,9 +43,9 @@ metadata:
 spec:
   podManagementPolicy: OrderedReady
   {{- if eq .Values.global.mode "cluster" }}
-  replicas: 1
-  {{- else }}
   replicas: {{ .Values.polaris.replicaCount }}
+  {{- else }}
+  replicas: 1
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
polaris 集群模式副本数当前默认为1，调整为取值{{ .Values.polaris.replicaCount }}

**Please provide issue(s) of this PR:**
Fixes #

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [X] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
