### PR TITLE
fix-shellcheck(SC1128) The shebang must be on the first line.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 set -e
 

--- a/build_cmdb.sh
+++ b/build_cmdb.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 workdir=$(dirname $(realpath $0))
 version=$(cat version 2>/dev/null)

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 if [ $# != 1 ]; then
     echo "e.g.: bash $0 v1.0"

--- a/common/api/v1/build.sh
+++ b/common/api/v1/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 # 安装protoc和protoc-gen-go插件
 #

--- a/common/api/v2/build.sh
+++ b/common/api/v2/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 # 安装protoc和protoc-gen-go插件
 #

--- a/import-format.sh
+++ b/import-format.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 # 格式化 go.mod
 go mod tidy -compat=1.17

--- a/tool/p.sh
+++ b/tool/p.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 curpath=$(pwd)
 

--- a/tool/start.sh
+++ b/tool/start.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 
 curpath=$(pwd)
 

--- a/tool/stop.sh
+++ b/tool/stop.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -13,7 +14,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-#!/bin/bash
 curpath=$(pwd)
 
 if [ "${0:0:1}" == "/" ]; then

--- a/vert.sh
+++ b/vert.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Tencent is pleased to support the open source community by making Polaris available.
 #
 # Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
@@ -14,7 +15,6 @@
 # specific language governing permissions and limitations under the License.
 
 
-#!/bin/bash
 
 set -ex         # Exit on error; debugging enabled.
 set -o pipefail # Fail a pipe if any sub-command fails.


### PR DESCRIPTION
The shebang must be on the first line. Delete blanks and move comments.shellcheck(SC1128) #814

A shebang only has an effect when it appears as the first line in a script. Specifically, the first two bytes of the file must be #!.

More external link see <https://www.shellcheck.net/wiki/SC1128>

**Please provide issue(s) of this PR:**
Fixes #

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [X] Installation
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [X] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
