### PR TITLE
Fix prometheus.yml bug

### DIFF
--- a/release/standalone/docker-compose/prometheus/prometheus.yml
+++ b/release/standalone/docker-compose/prometheus/prometheus.yml
@@ -11,10 +11,10 @@ scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: "prometheus"
     static_configs:
-      - targets: [ "http://localhost:9090" ]
+      - targets: [ "localhost:9090" ]
   - job_name: "push-metrics"
     static_configs:
-      - targets: [ "http://polaris-pushgateway:9091" ]
+      - targets: [ "polaris-pushgateway:9091" ]
   - job_name: "polaris-server"
     http_sd_configs:
       - url: "http://polaris-server:8090/prometheus/v1/clients"


### PR DESCRIPTION
fix prometheus.yml bug
the targets cannot start with  "http://"

Error logs:
ts=2023-04-13T09:21:39.900Z caller=main.go:434 level=error msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" err="parsing YAML file /etc/prometheus/prometheus.yml: \"http://localhost:9090\" is not a valid hostname"

**Please provide issue(s) of this PR:**
Fixes #

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] ApiServer
- [ ] Auth
- [x] Configuration
- [ ] Naming
- [ ] HealthCheck
- [ ] Metrics
- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
