### PR TITLE
修复通过服务别名拉取时，服务信息为源服务信息问题

### DIFF
--- a/service/client_v1.go
+++ b/service/client_v1.go
@@ -231,11 +231,8 @@ func (s *Server) ServiceInstancesCache(ctx context.Context, req *apiservice.Serv
 	// 填充service数据
 	resp.Service = service2Api(aliasFor)
 	resp.Service.Revision.Value = revision
-	// 若为服务别名，则变更为服务别名信息
-	if s.serviceIsAlias(serviceName, namespaceName) {
-		resp.Service.Name.Value = serviceName
-		resp.Service.Namespace.Value = namespaceName
-	}
+	resp.Service.Name.Value = serviceName
+	resp.Service.Namespace.Value = namespaceName
 	// 塞入源服务信息数据
 	resp.AliasFor = &apiservice.Service{
 		Namespace: utils.NewStringValue(aliasFor.Namespace),
@@ -496,22 +493,6 @@ func (s *Server) getServiceCache(name string, namespace string) *model.Service {
 		service.Meta = make(map[string]string)
 	}
 	return service
-}
-
-func (s *Server) serviceIsAlias(name string, namespace string) bool {
-	sc := s.caches.Service()
-	service := sc.GetServiceByName(name, namespace)
-	if service == nil {
-		return false
-	}
-	if service.IsAlias() {
-		service = sc.GetServiceByID(service.Reference)
-		if service == nil {
-			return false
-		}
-		return true
-	}
-	return false
 }
 
 func (s *Server) commonCheckDiscoverRequest(req *apiservice.Service, resp *apiservice.DiscoverResponse) bool {


### PR DESCRIPTION
spring cloud tencent discovery通过服务别名拉取时，拉取到的服务信息为源服务服务信息，未触发该服务别名服务发现事件，导致实际存在服务实例信息，实例列表却为空问题。

**Please provide issue(s) of this PR:**
Fixes #1183

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] ApiServer
- [ ] Auth
- [ ] Configuration
- [x] Naming
- [ ] HealthCheck
- [ ] Metrics
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
