### PR TITLE
fix(store/mysql,cache): 修复 SQL 列名错误、namespace metadata 未持久化与泳道组创建 panic

### DIFF
--- a/cache/service/lane.go
+++ b/cache/service/lane.go
@@ -428,6 +428,10 @@ func (lc *LaneCache) toPage(total uint32, items []*model.LaneGroupProto,
 
 // GetRule implements api.LaneCache.
 func (lc *LaneCache) GetRule(id string) *model.LaneGroup {
-	rule, _ := lc.rules.Load(id)
+	// id 不存在时 Load 返回零值 nil，调用方按返回 nil 处理，这里必须判空
+	rule, ok := lc.rules.Load(id)
+	if !ok || rule == nil {
+		return nil
+	}
 	return rule.LaneGroup
 }

--- a/store/mysql/admin.go
+++ b/store/mysql/admin.go
@@ -533,7 +533,9 @@ func (m *adminStore) BatchCleanDeletedClients(timeout time.Duration, batchSize u
 	log.Infof("[Store][database] batch clean soft deleted clients(%d)", batchSize)
 	var rows int64
 	err := m.master.processWithTransaction("batchCleanDeletedClients", func(tx *BaseTx) error {
-		mainStr := "delete from client where flag = 1 limit ?"
+		// 原实现只有一个占位符却传了两个参数，且未按 timeout 过滤；
+		// 补上 mtime 条件与 BatchCleanDeletedInstances 的语义保持一致
+		mainStr := "delete from client where flag = 1 and mtime <= FROM_UNIXTIME(UNIX_TIMESTAMP(SYSDATE()) - ?) limit ?"
 		result, err := tx.Exec(mainStr, int32(timeout.Seconds()), batchSize)
 		if err != nil {
 			log.Errorf("[Store][database] batch clean soft deleted clients(%d), err: %s", batchSize, err.Error())

--- a/store/mysql/client.go
+++ b/store/mysql/client.go
@@ -232,7 +232,7 @@ func batchCleanClientStats(tx *BaseTx, ids []string) error {
 }
 
 func (cs *clientStore) GetClientStat(clientID string) ([]*model.ClientStatStore, error) {
-	str := "select `target`, `port`, `protocol`, `path` from client_stat where client.id = ?"
+	str := "select `target`, `port`, `protocol`, `path` from client_stat where client_id = ?"
 	rows, err := cs.master.Query(str, clientID)
 	if err != nil {
 		log.Errorf("[Store][database] query client stat err: %s", err.Error())
@@ -455,7 +455,7 @@ func updateClientMain(tx *BaseTx, client *model.Client) error {
 
 // updateClientStat 更新client的stat表
 func updateClientStat(tx *BaseTx, client *model.Client) error {
-	deleteStr := "delete from client_stat where cliend_id = ?"
+	deleteStr := "delete from client_stat where client_id = ?"
 	if _, err := tx.Exec(deleteStr, client.Proto().GetId().GetValue()); err != nil {
 		return err
 	}

--- a/store/mysql/namespace.go
+++ b/store/mysql/namespace.go
@@ -49,12 +49,12 @@ func (ns *namespaceStore) AddNamespace(namespace *model.Namespace) error {
 
 			str := `
 			INSERT INTO namespace (name, comment, token, owner, ctime
-				, mtime, service_export_to)
+				, mtime, service_export_to, metadata)
 			VALUES (?, ?, ?, ?, sysdate()
-				, sysdate(), ?)
+				, sysdate(), ?, ?)
 			`
 			args := []interface{}{namespace.Name, namespace.Comment, namespace.Token, namespace.Owner,
-				utils.MustJson(namespace.ServiceExportTo)}
+				utils.MustJson(namespace.ServiceExportTo), utils.MustJson(namespace.Metadata)}
 			if _, err := tx.Exec(str, args...); err != nil {
 				return store.Error(err)
 			}
@@ -76,8 +76,10 @@ func (ns *namespaceStore) UpdateNamespace(namespace *model.Namespace) error {
 	}
 	return RetryTransaction("updateNamespace", func() error {
 		return ns.master.processWithTransaction("updateNamespace", func(tx *BaseTx) error {
-			str := "update namespace set owner = ?, comment = ?, service_export_to = ?, mtime = sysdate() where name = ?"
-			args := []interface{}{namespace.Owner, namespace.Comment, utils.MustJson(namespace.ServiceExportTo), namespace.Name}
+			str := "update namespace set owner = ?, comment = ?, service_export_to = ?, metadata = ?," +
+				" mtime = sysdate() where name = ?"
+			args := []interface{}{namespace.Owner, namespace.Comment, utils.MustJson(namespace.ServiceExportTo),
+				utils.MustJson(namespace.Metadata), namespace.Name}
 			if _, err := tx.Exec(str, args...); err != nil {
 				return store.Error(err)
 			}
@@ -254,7 +256,7 @@ func genNamespaceSelectSQL() string {
 	SELECT name, IFNULL(comment, ''), token
 	, owner, flag, UNIX_TIMESTAMP(ctime)
 	, UNIX_TIMESTAMP(mtime)
-	, IFNULL(service_export_to, '{}')
+	, IFNULL(service_export_to, '{}'), IFNULL(metadata, '{}')
 FROM namespace
 	`
 	return str
@@ -270,7 +272,7 @@ func namespaceFetchRows(rows *sql.Rows) ([]*model.Namespace, error) {
 	var out []*model.Namespace
 	var ctime, mtime int64
 	var flag int
-	var serviceExportTo string
+	var serviceExportTo, metadata string
 
 	for rows.Next() {
 		space := &model.Namespace{}
@@ -283,6 +285,7 @@ func namespaceFetchRows(rows *sql.Rows) ([]*model.Namespace, error) {
 			&ctime,
 			&mtime,
 			&serviceExportTo,
+			&metadata,
 		)
 		if err != nil {
 			log.Errorf("[Store][database] fetch namespace rows scan err: %s", err.Error())
@@ -293,6 +296,8 @@ func namespaceFetchRows(rows *sql.Rows) ([]*model.Namespace, error) {
 		space.ModifyTime = time.Unix(mtime, 0)
 		space.ServiceExportTo = map[string]struct{}{}
 		_ = json.Unmarshal([]byte(serviceExportTo), &space.ServiceExportTo)
+		space.Metadata = map[string]string{}
+		_ = json.Unmarshal([]byte(metadata), &space.Metadata)
 		space.Valid = true
 		if flag == 1 {
 			space.Valid = false

--- a/store/mysql/role.go
+++ b/store/mysql/role.go
@@ -65,12 +65,15 @@ VALUES (?, ?, ?, ?, ?
 }
 
 func (s *roleStore) savePrincipals(tx *BaseTx, role *authcommon.Role) error {
-	if _, err := tx.Exec("DELETE FROM auth_role_principal WHERE id = ?", role.ID); err != nil {
+	// auth_role_principal 的关联列是 role_id，表中没有 id 列
+	if _, err := tx.Exec("DELETE FROM auth_role_principal WHERE role_id = ?", role.ID); err != nil {
 		log.Error("[store][role] clean role principal info", zap.String("name", role.Name), zap.Error(err))
 		return err
 	}
 
-	insertTpl := "INSERT INTO auth_role_principal(role_id, principal_id, principal_role, IFNULL(extend_info, '')) VALUES (?, ?, ?)"
+	// 原实现的列列表里写了 IFNULL(extend_info, '')（函数不能出现在列列表中），
+	// 且四个列只给了三个占位符，与实际传入的四个参数不匹配
+	insertTpl := "INSERT INTO auth_role_principal(role_id, principal_id, principal_role, extend_info) VALUES (?, ?, ?, ?)"
 
 	for i := range role.Users {
 		args := []interface{}{role.ID, role.Users[i].PrincipalID, authcommon.PrincipalUser, utils.MustJson(role.Users[i].Extend)}


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #1430

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] ApiServer
- [x] Auth
- [ ] Configuration
- [x] Naming
- [ ] HealthCheck
- [ ] Metrics
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.

---

修复 #1430 中列出的 5 处缺陷，每处一个独立提交，便于分别 review 与取舍。

| 提交 | 文件 | 修复内容 |
|---|---|---|
| 1 | `store/mysql/namespace.go` | INSERT / UPDATE / SELECT 补上 `metadata` 列，与 boltdb 实现对齐 |
| 2 | `store/mysql/client.go` | `client.id` → `client_id`；`cliend_id` → `client_id` |
| 3 | `store/mysql/admin.go` | 补 `mtime` 过滤条件，使占位符与传入参数数量一致 |
| 4 | `store/mysql/role.go` | `DELETE` 条件列改为 `role_id`；`INSERT` 列列表去掉函数并补足占位符 |
| 5 | `cache/service/lane.go` | `GetRule` 判断 `SyncMap.Load` 的 ok 值，id 不存在时返回 nil |

改动范围 5 个文件、+27/-13，均为最小修复，未调整周边逻辑。

其中 3 处修复后行为变化明显：

- namespace 的 metadata 由「写入即丢弃」变为正常持久化，polaris-console 的 `checkGlobalRegistry` 得以按预期工作
- 角色携带成员时不再失败
- 创建泳道组不再 panic

**关于验证**

这些问题是在为 store 层适配 PostgreSQL 时，通过逐条执行 SQL 发现的。修复在 PostgreSQL 上已完整验证（等价改动 + 端到端读写）。

MySQL 侧目前只跑了仓库内已有的单元测试（`go build ./...`、`store/mysql` 与 `cache/service` 测试均通过）——现有测试未覆盖这些路径，因此结论主要基于 SQL 语义与表结构的比对。若需要，我可以补充 MySQL 环境下的实测结果，或为这几处补上测试用例。
